### PR TITLE
Use CommonJS module instead of ES

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Component } from 'vue';
 
 type createContext = (defaultValue: unknown) => { Provider: Component; Consumer: Component };
 
-export const createContext: createContext = (defaultValue) => {
+module.exports.createContext = (defaultValue) => {
   const _key = `_${Date.now()}${Math.random()}`;
   const _context = {
     from: _key,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "es2015",
+    "module": "commonjs",
     "target": "es5",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Make the package more compatible with different build infrastructures. Fixes #2 

Imports in ES style will still work if we use Webpack

```js
import {createContext} from 'vue-create-context'
```

We loose nothing as Tree Shaking in this small library makes no sense
